### PR TITLE
Un-Ignore two tests

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
@@ -85,8 +85,8 @@ public class CpsFlowDefinition2Test extends AbstractCpsFlowTest {
      * Verify that we kill endlessly recursive CPS code cleanly.
      */
     @Test
-    @Ignore /** Intermittent failures because triggers a longstanding unrelated SandboxResolvingClassloader bug
-     resolved in https://github.com/jenkinsci/script-security-plugin/pull/160 */
+    // @Ignore /** Intermittent failures because triggers a longstanding unrelated SandboxResolvingClassloader bug
+    // resolved in https://github.com/jenkinsci/script-security-plugin/pull/160 */
     public void endlessRecursion() throws Exception {
         Assume.assumeTrue(!Functions.isWindows());  // Sidestep false failures specific to a few Windows build environments.
         String script = "def getThing(){return thing == null}; \n" +
@@ -115,8 +115,8 @@ public class CpsFlowDefinition2Test extends AbstractCpsFlowTest {
      *  we don't trigger other forms of failure with the StackOverflowError.
      */
     @Test
-    @Ignore  /** Intermittent failures because triggers a longstanding unrelated SandboxResolvingClassloader bug
-                 resolved in https://github.com/jenkinsci/script-security-plugin/pull/160 */
+    // @Ignore  /** Intermittent failures because triggers a longstanding unrelated SandboxResolvingClassloader bug
+    //              resolved in https://github.com/jenkinsci/script-security-plugin/pull/160 */
     public void endlessRecursionNonCPS() throws Exception {
         Assume.assumeTrue(!Functions.isWindows());  // Sidestep false failures specific to a few Windows build environments.
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
@@ -43,6 +43,7 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Ignore;
+import org.junit.
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
@@ -88,6 +88,8 @@ public class CpsFlowDefinition2Test extends AbstractCpsFlowTest {
     // @Ignore /** Intermittent failures because triggers a longstanding unrelated SandboxResolvingClassloader bug
     // resolved in https://github.com/jenkinsci/script-security-plugin/pull/160 */
     public void endlessRecursion() throws Exception {
+        // Cheat so I can make sure I'm running the version of script-security that I think I am.
+        // Thread.sleep(30000000);
         Assume.assumeTrue(!Functions.isWindows());  // Sidestep false failures specific to a few Windows build environments.
         String script = "def getThing(){return thing == null}; \n" +
                 "node { echo getThing(); } ";

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
@@ -43,7 +43,6 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Ignore;
-import org.junit.
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
@@ -86,8 +86,6 @@ public class CpsFlowDefinition2Test extends AbstractCpsFlowTest {
      */
     @Test
     public void endlessRecursion() throws Exception {
-        // Cheat so I can make sure I'm running the version of script-security that I think I am.
-        // Thread.sleep(30000000);
         Assume.assumeTrue(!Functions.isWindows());  // Sidestep false failures specific to a few Windows build environments.
         String script = "def getThing(){return thing == null}; \n" +
                 "node { echo getThing(); } ";

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition2Test.java
@@ -85,8 +85,6 @@ public class CpsFlowDefinition2Test extends AbstractCpsFlowTest {
      * Verify that we kill endlessly recursive CPS code cleanly.
      */
     @Test
-    // @Ignore /** Intermittent failures because triggers a longstanding unrelated SandboxResolvingClassloader bug
-    // resolved in https://github.com/jenkinsci/script-security-plugin/pull/160 */
     public void endlessRecursion() throws Exception {
         // Cheat so I can make sure I'm running the version of script-security that I think I am.
         // Thread.sleep(30000000);
@@ -117,8 +115,6 @@ public class CpsFlowDefinition2Test extends AbstractCpsFlowTest {
      *  we don't trigger other forms of failure with the StackOverflowError.
      */
     @Test
-    // @Ignore  /** Intermittent failures because triggers a longstanding unrelated SandboxResolvingClassloader bug
-    //              resolved in https://github.com/jenkinsci/script-security-plugin/pull/160 */
     public void endlessRecursionNonCPS() throws Exception {
         Assume.assumeTrue(!Functions.isWindows());  // Sidestep false failures specific to a few Windows build environments.
 


### PR DESCRIPTION
# Description
These two tests are the ones which were previously failing intermittently before the move to script-security 1.60. All this PR does is un-`@Ignore` them, since they are passing now.

I ran the test 100 times on each of two branches: 

- @bitwiseman's [branch](https://github.com/bitwiseman/workflow-cps-plugin/tree/patch-1), which I'm submitting the PR to, which includes script-security 1.60. This showed a 100% pass rate.
- [This one](https://github.com/jenkinsci/workflow-cps-plugin/compare/master...kshultzCB:master-with-tests-un-ignored), which is [using script-security 1.58](https://github.com/kshultzCB/workflow-cps-plugin/blob/eb8355ed4137cba57944ade469b453281e109063/pom.xml#L99-L103). When run here, I observed four (4) timeouts, and two (2) failures.

The failures showed the following `StackOverflowError`, which I've shortened here:
```
Pipeline] End of Pipeline
java.lang.StackOverflowError
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxResolvingClassLoader$4$1.load(SandboxResolvingClassLoader.java:80)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxResolvingClassLoader$4$1.load(SandboxResolvingClassLoader.java:78)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3568)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2350)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2313)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2228)
	at com.google.common.cache.LocalCache.get(LocalCache.java:3965)
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3969)
	at com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4829)
	at com.google.common.cache.LocalCache$LocalManualCache.getUnchecked(LocalCache.java:4834)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxResolvingClassLoader.loadClass(SandboxResolvingClassLoader.java:51)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:411)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell$TimingLoader.loadClass(CpsGroovyShell.java:161)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:411)
	at groovy.lang.GroovyClassLoader.loadClass(GroovyClassLoader.java:677)
	at groovy.lang.GroovyClassLoader.loadClass(GroovyClassLoader.java:787)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:411)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell$TimingLoader.loadClass(CpsGroovyShell.java:161)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:411)

...snip...

```